### PR TITLE
Update requirements and GitHub action settings

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -53,6 +53,7 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+        cache: "pip"  # https://github.com/actions/setup-python?tab=readme-ov-file#caching-packages-dependencies
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11"]
     services:
       db:
         image: postgres:16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,14 @@
-django
-mysqlclient
-django-allauth
-django-debug-toolbar
-pylint-django
-psycopg2-binary
-python-decouple
-python-dotenv
+django >= 4.2, < 5.0
+mysqlclient >= 2.0.3
+django-allauth >= 0.57.0
+django-debug-toolbar >= 4.2
+pylint-django >= 2.5.3
+psycopg2-binary >= 2.9.9
+python-decouple >= 3.8
+python-dotenv >= 1.0
+crispy-bootstrap5 >= 0.7
+django-crispy-forms >= 2.0
 
 # for heroku
-gunicorn
-django-heroku
-sendgrid
-django-crispy-forms
-crispy-bootstrap5
+gunicorn >= 21.2.0
+django-heroku >= 0.3.1


### PR DESCRIPTION
- Python 3.11のみでActionsを回すように変更（herokuのコンテナが3.11.5なので）
- requirements.txtでバージョン指定するように変更（**Django<5.0でないとエラーになる**）
